### PR TITLE
Remove Sentry integration

### DIFF
--- a/app/(tabs)/Debug.tsx
+++ b/app/(tabs)/Debug.tsx
@@ -22,7 +22,6 @@ import axios, { isAxiosError } from 'axios';
 import { MANGA_API_URL } from '@/constants/Config';
 import { useCloudflareDetection } from '@/hooks/useCloudflareDetection';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import * as Sentry from '@sentry/react-native';
 
 export default function DebugScreen() {
   const { theme } = useTheme();
@@ -39,9 +38,6 @@ export default function DebugScreen() {
   });
   const [isTriggering, setIsTriggering] = useState(false);
   const [log, setLog] = useState<string[]>([]);
-  const [lastSentryEventId, setLastSentryEventId] = useState<string | null>(
-    null
-  );
   const CHAPTER_GUIDE_KEY = 'chapter_guide_seen';
 
   const addLog = (message: string) => {
@@ -538,43 +534,6 @@ export default function DebugScreen() {
     });
   };
 
-  const sendSentryTestError = () => {
-    const eventId = Sentry.captureException(
-      new Error('Debug menu Sentry test error')
-    );
-    setLastSentryEventId(eventId ?? null);
-    showAlertWithConfig({
-      title: 'Sentry Test Error',
-      message: eventId
-        ? `Sent test error (event ${eventId}).`
-        : 'Sent test error.',
-      options: [{ text: 'OK', onPress: () => setShowAlert(false) }],
-    });
-  };
-
-  const sendSentryTestMessage = () => {
-    const eventId = Sentry.captureMessage(
-      'Debug menu Sentry test message',
-      'info'
-    );
-    setLastSentryEventId(eventId ?? null);
-    showAlertWithConfig({
-      title: 'Sentry Test Message',
-      message: eventId
-        ? `Sent diagnostic message (event ${eventId}).`
-        : 'Sent diagnostic message.',
-      options: [{ text: 'OK', onPress: () => setShowAlert(false) }],
-    });
-  };
-
-  const showSentryEventId = () => {
-    showAlertWithConfig({
-      title: 'Last Sentry Event',
-      message: lastSentryEventId ?? 'No Sentry events sent yet.',
-      options: [{ text: 'OK', onPress: () => setShowAlert(false) }],
-    });
-  };
-
   return (
     <SafeAreaView style={styles.container}>
       <ScrollView
@@ -662,34 +621,6 @@ export default function DebugScreen() {
             <Ionicons name="trash-outline" size={24} color={colors.text} />
             <Text style={styles.optionText}>Clear Image Cache</Text>
           </TouchableOpacity>
-        </View>
-
-        <View style={styles.section}>
-          <Text style={styles.sectionTitle}>Sentry</Text>
-
-          <TouchableOpacity style={styles.option} onPress={sendSentryTestError}>
-            <Ionicons name="bug-outline" size={24} color={colors.text} />
-            <Text style={styles.optionText}>Send Test Error</Text>
-          </TouchableOpacity>
-
-          <TouchableOpacity
-            style={styles.option}
-            onPress={sendSentryTestMessage}
-          >
-            <Ionicons
-              name="paper-plane-outline"
-              size={24}
-              color={colors.text}
-            />
-            <Text style={styles.optionText}>Send Test Message</Text>
-          </TouchableOpacity>
-
-          {lastSentryEventId && (
-            <TouchableOpacity style={styles.option} onPress={showSentryEventId}>
-              <Ionicons name="list-outline" size={24} color={colors.text} />
-              <Text style={styles.optionText}>View Last Event ID</Text>
-            </TouchableOpacity>
-          )}
         </View>
       </ScrollView>
 

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -22,21 +22,6 @@ import { useNavigationPerf } from '@/hooks/useNavigationPerf';
 import { logger } from '@/utils/logger';
 import Constants from 'expo-constants';
 import { downloadManagerService } from '@/services/downloadManager';
-import * as Sentry from '@sentry/react-native';
-
-Sentry.init({
-  dsn: 'https://7bcd6652c918fd0f44f3d78deafa1ab9@o4510380885082112.ingest.de.sentry.io/4510380894060624',
-
-  // Adds more context data to events (IP address, cookies, user, etc.)
-  // For more information, visit: https://docs.sentry.io/platforms/react-native/data-management/data-collected/
-  sendDefaultPii: true,
-
-  // Enable Logs
-  enableLogs: true,
-
-  // uncomment the line below to enable Spotlight (https://spotlightjs.com)
-  // spotlight: __DEV__,
-});
 
 SplashScreen.preventAutoHideAsync();
 
@@ -79,7 +64,7 @@ function RootLayoutNav() {
   );
 }
 
-export default Sentry.wrap(function RootLayout() {
+export default function RootLayout() {
   useEffect(() => {
     if (!isDebugEnabled()) return;
     enableAsyncStorageLogging();
@@ -131,4 +116,4 @@ export default Sentry.wrap(function RootLayout() {
       </ThemeProvider>
     </GestureHandlerRootView>
   );
-});
+}


### PR DESCRIPTION
## Summary
- remove all Sentry initialization and wrapping from the root layout
- remove Sentry debug actions and state from the debug screen

## Testing
- bun run lint *(fails: expo CLI not available in environment)*
- bunx expo-doctor *(fails: registry access blocked with 403)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693c515b6ac08329a9d109280489987d)