### PR TITLE
Fix RTL/LTR by honoring manga settings and stopping inverted index re…

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "manganess",
     "slug": "manganess",
-    "version": "1.11",
+    "version": "1.12",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "com.iroan.manganess",
@@ -41,7 +41,7 @@
       }
     },
     "owner": "iroan",
-    "runtimeVersion": "1.11.0",
+    "runtimeVersion": "1.12.0",
     "updates": {
       "enabled": true,
       "fallbackToCacheTimeout": 0,

--- a/app/(tabs)/manga/[id]/chapter/[chapterNumber].tsx
+++ b/app/(tabs)/manga/[id]/chapter/[chapterNumber].tsx
@@ -62,7 +62,9 @@ import getStyles from './[chapterNumber].styles';
 import { logger } from '@/utils/logger';
 import {
   isVerticalOnlyContentType,
+  normalizeContentTypeLabel,
   resolveEffectiveReaderLayout,
+  resolveReaderContentProfile,
 } from '@/utils/contentType';
 import { isDebugEnabled } from '@/constants/env';
 import {
@@ -443,12 +445,17 @@ export default function ReadChapterScreen() {
 
   // Resolve the effective reader layout from the reading mode setting.
   // Manhwa / manhua / webtoon titles are always vertical — LTR/RTL never apply.
-  // `auto` for manga falls back to aspect-ratio detection (manga=ltr).
-  const isVerticalOnlyTitle = useMemo(
+  // `auto` for unknown types falls back to aspect-ratio detection.
+  // Tall manga pages must NOT steal the manhwa profile or hide LTR/RTL.
+  const activeReaderProfile: ReaderContentProfile = useMemo(
     () =>
-      isVerticalOnlyContentType(mangaDetails?.type) || contentType === 'manhwa',
+      resolveReaderContentProfile({
+        titleType: mangaDetails?.type ?? null,
+        detectedType: contentType,
+      }),
     [mangaDetails?.type, contentType]
   );
+  const isVerticalOnlyTitle = activeReaderProfile === 'manhwa';
 
   const effectiveLayout = useMemo<'vertical' | 'ltr' | 'rtl' | null>(
     () =>
@@ -546,10 +553,6 @@ export default function ReadChapterScreen() {
         return Colors[colorScheme].background;
     }
   }, [readerBackground, colorScheme]);
-
-  const activeReaderProfile: ReaderContentProfile = isVerticalOnlyTitle
-    ? 'manhwa'
-    : 'manga';
 
   const applyReaderProfile = useCallback(
     (profile: {
@@ -962,6 +965,10 @@ export default function ReadChapterScreen() {
     if (isVerticalOnlyContentType(mangaDetails?.type)) {
       return Promise.resolve('manhwa' as const);
     }
+    // Explicit manga titles keep page modes; tall pages are normal for manga.
+    if (normalizeContentTypeLabel(mangaDetails?.type) === 'manga') {
+      return Promise.resolve('manga' as const);
+    }
     if (!images || images.length === 0) return Promise.resolve('manga' as const);
 
     const sampleSize = Math.min(3, images.length);
@@ -1331,12 +1338,11 @@ export default function ReadChapterScreen() {
         index: horizontalScrollIndexForPage({
           pageIndex: currentPage,
           pageCount: downloadedImages.length,
-          inverted: isInvertedLayout,
         }),
         animated: true,
       });
     }
-  }, [currentPage, isHorizontalLayout, downloadedImages, isInvertedLayout]);
+  }, [currentPage, isHorizontalLayout, downloadedImages]);
 
   // Always reset reader position when a new chapter loads offline
   useEffect(() => {
@@ -1357,7 +1363,6 @@ export default function ReadChapterScreen() {
             index: horizontalScrollIndexForPage({
               pageIndex: 0,
               pageCount: downloadedImages.length,
-              inverted: effectiveLayout === 'rtl',
             }),
             animated: false,
           });
@@ -1656,7 +1661,6 @@ export default function ReadChapterScreen() {
               offsetX: offset,
               pageWidth,
               pageCount: sortedImages.length,
-              inverted: isInvertedLayout,
             })
           );
         }}

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "manganess",
   "main": "expo-router/entry",
-  "version": "1.11",
+  "version": "1.12",
   "expo": {
     "name": "manganess",
     "slug": "manganess",
-    "version": "1.11",
+    "version": "1.12",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "com.iroan.manganess",

--- a/types/settings.ts
+++ b/types/settings.ts
@@ -35,7 +35,8 @@ export type ThemeType = 'light' | 'dark' | 'system';
 
 /**
  * Reading mode for the chapter reader.
- * - `auto`: detect from title type / image aspect (manhwa=vertical, manga=horizontal LTR)
+ * - `auto`: detect from title type / image aspect (manhwa=vertical, manga=horizontal LTR).
+ *   Explicit manga titles use LTR immediately; aspect detection is only for unknown types.
  * - `vertical`: force vertical long-strip (webtoon) scrolling
  * - `ltr`: force horizontal page-by-page, left-to-right (manga only; ignored for manhwa)
  * - `rtl`: force horizontal page-by-page, right-to-left (manga only; ignored for manhwa)

--- a/utils/__tests__/contentType.test.ts
+++ b/utils/__tests__/contentType.test.ts
@@ -1,7 +1,9 @@
 import {
+  isExplicitMangaContentType,
   isVerticalOnlyContentType,
   normalizeContentTypeLabel,
   resolveEffectiveReaderLayout,
+  resolveReaderContentProfile,
 } from '@/utils/contentType';
 
 describe('contentType', () => {
@@ -28,6 +30,51 @@ describe('contentType', () => {
     });
   });
 
+  describe('isExplicitMangaContentType', () => {
+    it('recognizes manga labels', () => {
+      expect(isExplicitMangaContentType('Manga')).toBe(true);
+      expect(isExplicitMangaContentType('manga')).toBe(true);
+      expect(isExplicitMangaContentType('Manhwa')).toBe(false);
+      expect(isExplicitMangaContentType(null)).toBe(false);
+    });
+  });
+
+  describe('resolveReaderContentProfile', () => {
+    it('uses the manhwa profile for vertical-only provider types', () => {
+      expect(
+        resolveReaderContentProfile({
+          titleType: 'Manhwa',
+          detectedType: 'manga',
+        })
+      ).toBe('manhwa');
+    });
+
+    it('keeps the manga profile when the provider says Manga', () => {
+      expect(
+        resolveReaderContentProfile({
+          titleType: 'Manga',
+          detectedType: 'manhwa',
+        })
+      ).toBe('manga');
+    });
+
+    it('falls back to aspect detection when title type is unknown', () => {
+      expect(
+        resolveReaderContentProfile({
+          titleType: null,
+          detectedType: 'manhwa',
+        })
+      ).toBe('manhwa');
+
+      expect(
+        resolveReaderContentProfile({
+          titleType: null,
+          detectedType: 'manga',
+        })
+      ).toBe('manga');
+    });
+  });
+
   describe('resolveEffectiveReaderLayout', () => {
     it('forces vertical for manhwa even when reading mode is LTR or RTL', () => {
       expect(
@@ -45,14 +92,22 @@ describe('contentType', () => {
       ).toBe('vertical');
     });
 
-    it('forces vertical when aspect detection finds manhwa panels', () => {
+    it('honors explicit LTR/RTL even when aspect detection says manhwa', () => {
       expect(
         resolveEffectiveReaderLayout({
           readingMode: 'rtl',
           titleType: 'Manga',
           detectedType: 'manhwa',
         })
-      ).toBe('vertical');
+      ).toBe('rtl');
+
+      expect(
+        resolveEffectiveReaderLayout({
+          readingMode: 'ltr',
+          titleType: null,
+          detectedType: 'manhwa',
+        })
+      ).toBe('ltr');
     });
 
     it('honors LTR/RTL for manga titles', () => {
@@ -73,11 +128,29 @@ describe('contentType', () => {
       ).toBe('rtl');
     });
 
-    it('uses auto detection for manga when mode is auto', () => {
+    it('uses provider manga type for auto without waiting on detection', () => {
       expect(
         resolveEffectiveReaderLayout({
           readingMode: 'auto',
           titleType: 'Manga',
+          detectedType: null,
+        })
+      ).toBe('ltr');
+    });
+
+    it('uses auto detection when mode is auto and type is unknown', () => {
+      expect(
+        resolveEffectiveReaderLayout({
+          readingMode: 'auto',
+          titleType: null,
+          detectedType: 'manhwa',
+        })
+      ).toBe('vertical');
+
+      expect(
+        resolveEffectiveReaderLayout({
+          readingMode: 'auto',
+          titleType: null,
           detectedType: 'manga',
         })
       ).toBe('ltr');

--- a/utils/__tests__/readerPageIndex.test.ts
+++ b/utils/__tests__/readerPageIndex.test.ts
@@ -8,13 +8,12 @@ describe('readerPageIndex', () => {
   const pageCount = 5;
 
   describe('horizontalPageIndexFromOffset', () => {
-    it('maps LTR offsets to the visible page index', () => {
+    it('maps offsets to the data page index', () => {
       expect(
         horizontalPageIndexFromOffset({
           offsetX: 0,
           pageWidth,
           pageCount,
-          inverted: false,
         })
       ).toBe(0);
 
@@ -23,59 +22,67 @@ describe('readerPageIndex', () => {
           offsetX: 800,
           pageWidth,
           pageCount,
-          inverted: false,
         })
       ).toBe(2);
     });
 
-    it('maps inverted RTL offsets to the logical page index', () => {
+    it('clamps out-of-range offsets', () => {
       expect(
         horizontalPageIndexFromOffset({
-          offsetX: 0,
+          offsetX: -400,
           pageWidth,
           pageCount,
-          inverted: true,
         })
-      ).toBe(4);
+      ).toBe(0);
 
       expect(
         horizontalPageIndexFromOffset({
-          offsetX: 800,
+          offsetX: 4000,
           pageWidth,
           pageCount,
-          inverted: true,
         })
-      ).toBe(2);
+      ).toBe(4);
     });
   });
 
   describe('horizontalScrollIndexForPage', () => {
-    it('returns the same index for LTR lists', () => {
-      expect(
-        horizontalScrollIndexForPage({
-          pageIndex: 2,
-          pageCount,
-          inverted: false,
-        })
-      ).toBe(2);
-    });
-
-    it('mirrors the index for inverted RTL lists', () => {
+    it('returns the data index for programmatic scroll', () => {
       expect(
         horizontalScrollIndexForPage({
           pageIndex: 0,
           pageCount,
-          inverted: true,
         })
-      ).toBe(4);
+      ).toBe(0);
+
+      expect(
+        horizontalScrollIndexForPage({
+          pageIndex: 2,
+          pageCount,
+        })
+      ).toBe(2);
 
       expect(
         horizontalScrollIndexForPage({
           pageIndex: 4,
           pageCount,
-          inverted: true,
+        })
+      ).toBe(4);
+    });
+
+    it('clamps out-of-range page indices', () => {
+      expect(
+        horizontalScrollIndexForPage({
+          pageIndex: -1,
+          pageCount,
         })
       ).toBe(0);
+
+      expect(
+        horizontalScrollIndexForPage({
+          pageIndex: 99,
+          pageCount,
+        })
+      ).toBe(4);
     });
   });
 });

--- a/utils/contentType.ts
+++ b/utils/contentType.ts
@@ -30,11 +30,47 @@ export function isVerticalOnlyContentType(
 }
 
 /**
+ * True when the provider explicitly labeled the title as page-format manga.
+ * Explicit manga must not be forced into the manhwa profile by tall-page
+ * aspect detection (most manga pages are taller than wide).
+ */
+export function isExplicitMangaContentType(
+  type: string | null | undefined
+): boolean {
+  return normalizeContentTypeLabel(type) === 'manga';
+}
+
+/**
+ * Which reader settings profile to use for a title.
+ *
+ * Provider type wins. Aspect detection is only a fallback when the title type
+ * is missing or ambiguous — never when the provider said "Manga".
+ */
+export function resolveReaderContentProfile(options: {
+  titleType?: string | null;
+  detectedType?: 'manhwa' | 'manga' | null;
+}): 'manga' | 'manhwa' {
+  const { titleType, detectedType } = options;
+
+  if (isVerticalOnlyContentType(titleType)) {
+    return 'manhwa';
+  }
+  if (isExplicitMangaContentType(titleType)) {
+    return 'manga';
+  }
+  if (detectedType === 'manhwa') {
+    return 'manhwa';
+  }
+  return 'manga';
+}
+
+/**
  * Resolve the effective reader layout for a title.
  *
- * Vertical-only titles always return `vertical`, even if the user preference
- * is LTR/RTL. Manga (and unknown titles) follow the reading-mode preference,
- * with `auto` falling back to detected image layout.
+ * Vertical-only provider types always return `vertical`. Explicit LTR/RTL/
+ * vertical preferences are honored for every other title — including manga
+ * pages that aspect detection might misclassify as manhwa. `auto` uses
+ * detection only when the provider type does not already decide the layout.
  */
 export function resolveEffectiveReaderLayout(options: {
   readingMode: 'auto' | 'vertical' | 'ltr' | 'rtl';
@@ -44,18 +80,21 @@ export function resolveEffectiveReaderLayout(options: {
 }): 'vertical' | 'ltr' | 'rtl' | null {
   const { readingMode, titleType, detectedType } = options;
 
-  const verticalOnly =
-    isVerticalOnlyContentType(titleType) || detectedType === 'manhwa';
-
-  if (verticalOnly) {
+  // Provider manhwa/webtoon — never page modes.
+  if (isVerticalOnlyContentType(titleType)) {
     return 'vertical';
   }
 
+  // Explicit user choice always wins for non-vertical-only titles.
   if (readingMode === 'vertical') return 'vertical';
   if (readingMode === 'ltr') return 'ltr';
   if (readingMode === 'rtl') return 'rtl';
 
-  // auto — manga defaults to LTR once detection finishes
+  // auto — prefer provider type, then aspect detection.
+  if (isExplicitMangaContentType(titleType)) {
+    return 'ltr';
+  }
+  if (detectedType === 'manhwa') return 'vertical';
   if (detectedType === 'manga') return 'ltr';
   return null;
 }

--- a/utils/readerPageIndex.ts
+++ b/utils/readerPageIndex.ts
@@ -1,38 +1,34 @@
+/**
+ * Map horizontal FlatList scroll metrics to logical page indices.
+ *
+ * React Native's `inverted` FlatList uses a scale transform of -1. Data indices
+ * and `contentOffset` still line up the same way as a normal list — do not
+ * mirror the index when `inverted` is set, or RTL will open on the last page
+ * and edge navigation / progress will fight the list.
+ */
+
 export function horizontalPageIndexFromOffset(options: {
   offsetX: number;
   pageWidth: number;
   pageCount: number;
-  inverted: boolean;
 }): number {
-  const { offsetX, pageWidth, pageCount, inverted } = options;
+  const { offsetX, pageWidth, pageCount } = options;
   if (pageCount <= 0 || pageWidth <= 0) {
     return 0;
   }
 
   const rawIndex = Math.round(offsetX / pageWidth);
-  const clampedIndex = Math.max(0, Math.min(pageCount - 1, rawIndex));
-
-  if (!inverted) {
-    return clampedIndex;
-  }
-
-  return pageCount - 1 - clampedIndex;
+  return Math.max(0, Math.min(pageCount - 1, rawIndex));
 }
 
 export function horizontalScrollIndexForPage(options: {
   pageIndex: number;
   pageCount: number;
-  inverted: boolean;
 }): number {
-  const { pageIndex, pageCount, inverted } = options;
+  const { pageIndex, pageCount } = options;
   if (pageCount <= 0) {
     return 0;
   }
 
-  const clampedPage = Math.max(0, Math.min(pageCount - 1, pageIndex));
-  if (!inverted) {
-    return clampedPage;
-  }
-
-  return pageCount - 1 - clampedPage;
+  return Math.max(0, Math.min(pageCount - 1, pageIndex));
 }


### PR DESCRIPTION
…mapping.

Tall-page aspect detection was forcing the manhwa profile and ignoring LTR/RTL; inverted FlatList index mirroring also opened RTL chapters on the wrong page.